### PR TITLE
Add Discord slash command support

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1234,10 +1234,17 @@ class MusicBot(discord.Client):
                 player.current_entry.url
             )
 
-        self.server_data[guild.id].last_np_msg = await self.safe_send_message(
-            np_channel,
-            content,
-        )
+        np_msg = await self.safe_send_message(np_channel, content)
+        self.server_data[guild.id].last_np_msg = np_msg
+
+        if np_msg:
+            try:
+                from musicbot.slash.utility import NowPlayingView
+                view = NowPlayingView(self, player, auto_delete=False)
+                view.message = np_msg
+                await np_msg.edit(view=view)
+            except Exception:
+                log.debug("Could not attach NowPlayingView to auto-NP message", exc_info=True)
 
         # TODO: Check channel voice state?
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -241,6 +241,11 @@ class MusicBot(discord.Client):
         intents.presences = False
         super().__init__(intents=intents)
 
+        self.tree = discord.app_commands.CommandTree(self)
+
+        from musicbot.slash import setup as slash_setup
+        slash_setup(self)
+
     def create_task(
         self,
         coro: "Coroutine[Any, Any, Any]",
@@ -2512,6 +2517,14 @@ class MusicBot(discord.Client):
                 self.server_data[guild.id].is_ready()
                 # context switch to give scheduled task an execution window.
                 await asyncio.sleep(0)
+
+        # Sync slash commands to all guilds for instant availability.
+        for guild in self.guilds:
+            try:
+                await self.tree.sync(guild=guild)
+                log.info("Synced slash commands to guild: %s", guild.name)
+            except discord.HTTPException as e:
+                log.warning("Failed to sync slash commands to %s: %s", guild.name, e)
 
     async def _on_ready_always(self) -> None:
         """

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2873,7 +2873,14 @@ class MusicBot(discord.Client):
                 [event.wait()], timeout=self.config.leave_player_inactive_for
             )
         except asyncio.TimeoutError:
-            if not player.is_playing and player.voice_client.is_connected():
+            # Re-fetch the current player — the original reference may be stale
+            # if cmd_reconnect replaced it with a new player object.
+            current_player = self.get_player_in(guild)
+            if (
+                current_player
+                and not current_player.is_playing
+                and current_player.voice_client.is_connected()
+            ):
                 log.info(
                     "Player activity timer for %s has expired. Disconnecting.",
                     guild.name,
@@ -3051,6 +3058,14 @@ class MusicBot(discord.Client):
 
         await self.disconnect_voice_client(guild)
         await asyncio.sleep(1)
+
+        # Reset the inactivity event so the new player can register its own timer.
+        # The old timer coroutine holds a stale player reference and may still be
+        # running; clearing the event here unblocks handle_player_inactivity for
+        # the new player.
+        inactivity_event = self.server_data[guild.id].get_event("inactive_player_timer")
+        inactivity_event.deactivate()
+        inactivity_event.clear()
 
         new_player = await self.get_player(voice_channel, create=True)
         new_player.playlist.entries = deque(saved_entries)

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2519,8 +2519,11 @@ class MusicBot(discord.Client):
                 await asyncio.sleep(0)
 
         # Sync slash commands to all guilds for instant availability.
+        # copy_global_to is required because commands are registered globally
+        # in the tree; guild sync only sends guild-specific commands otherwise.
         for guild in self.guilds:
             try:
+                self.tree.copy_global_to(guild=guild)
                 await self.tree.sync(guild=guild)
                 log.info("Synced slash commands to guild: %s", guild.name)
             except discord.HTTPException as e:
@@ -9253,6 +9256,7 @@ class MusicBot(discord.Client):
 
         # Re-sync slash commands for this guild.
         try:
+            self.tree.copy_global_to(guild=guild)
             await self.tree.sync(guild=guild)
             log.info("Synced slash commands to guild: %s", guild.name)
         except discord.HTTPException as e:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -9251,6 +9251,13 @@ class MusicBot(discord.Client):
         """
         log.info("Bot has been added to guild: %s", guild.name)
 
+        # Re-sync slash commands for this guild.
+        try:
+            await self.tree.sync(guild=guild)
+            log.info("Synced slash commands to guild: %s", guild.name)
+        except discord.HTTPException as e:
+            log.warning("Failed to sync slash commands to %s: %s", guild.name, e)
+
         # Leave guilds if the owner is not a member and configured to do so.
         if self.config.leavenonowners:
             # Get the owner so we can notify them of the leave via DM.

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,13 +33,16 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
-    from musicbot.slash import admin, control, playback, playback_options, queue, utility
+    from musicbot.slash import (
+        admin, control, enhancements, playback, playback_options, queue, utility
+    )
     playback.register(bot)
     playback_options.register(bot)
     queue.register(bot)
     control.register(bot)
     utility.register(bot)
     admin.register(bot)
+    enhancements.register(bot)
 
     @bot.tree.error
     async def on_tree_error(

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,11 +33,12 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
-    from musicbot.slash import control, playback, playback_options, queue
+    from musicbot.slash import control, playback, playback_options, queue, utility
     playback.register(bot)
     playback_options.register(bot)
     queue.register(bot)
     control.register(bot)
+    utility.register(bot)
 
     @bot.tree.error
     async def on_tree_error(

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,8 +33,9 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
-    from musicbot.slash import playback
+    from musicbot.slash import playback, queue
     playback.register(bot)
+    queue.register(bot)
 
     @bot.tree.error
     async def on_tree_error(

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,6 +33,8 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
+    from musicbot.slash import playback
+    playback.register(bot)
 
     @bot.tree.error
     async def on_tree_error(

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,10 +33,11 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
-    from musicbot.slash import playback, playback_options, queue
+    from musicbot.slash import control, playback, playback_options, queue
     playback.register(bot)
     playback_options.register(bot)
     queue.register(bot)
+    control.register(bot)
 
     @bot.tree.error
     async def on_tree_error(

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,12 +33,13 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
-    from musicbot.slash import control, playback, playback_options, queue, utility
+    from musicbot.slash import admin, control, playback, playback_options, queue, utility
     playback.register(bot)
     playback_options.register(bot)
     queue.register(bot)
     control.register(bot)
     utility.register(bot)
+    admin.register(bot)
 
     @bot.tree.error
     async def on_tree_error(
@@ -46,6 +47,9 @@ def setup(bot: "MusicBot") -> None:
         error: app_commands.AppCommandError,
     ) -> None:
         original = getattr(error, "original", error)
+        # Let restart/terminate signals propagate to the main event loop.
+        if isinstance(original, (exceptions.RestartSignal, exceptions.TerminateSignal)):
+            raise original
         if isinstance(original, exceptions.MusicbotException):
             await respond_error(interaction, _format_error(original))
         else:

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -1,0 +1,47 @@
+"""
+DJ Roomba slash commands package.
+Call setup() once from MusicBot.__init__ to register all commands
+and the global error handler with the bot's CommandTree.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.slash.responses import respond_error
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+
+log = logging.getLogger(__name__)
+
+
+def _format_error(error: exceptions.MusicbotException) -> str:
+    """Format a MusicbotException message with its fmt_args."""
+    msg = error.message
+    if error.fmt_args:
+        try:
+            msg = msg % error.fmt_args
+        except (KeyError, TypeError):
+            pass
+    return msg
+
+
+def setup(bot: "MusicBot") -> None:
+    """Register all slash commands and the global error handler."""
+
+    @bot.tree.error
+    async def on_tree_error(
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        original = getattr(error, "original", error)
+        if isinstance(original, exceptions.MusicbotException):
+            await respond_error(interaction, _format_error(original))
+        else:
+            log.exception("Unhandled slash command error", exc_info=error)
+            await respond_error(interaction, "An unexpected error occurred.")

--- a/musicbot/slash/__init__.py
+++ b/musicbot/slash/__init__.py
@@ -33,8 +33,9 @@ def _format_error(error: exceptions.MusicbotException) -> str:
 
 def setup(bot: "MusicBot") -> None:
     """Register all slash commands and the global error handler."""
-    from musicbot.slash import playback, queue
+    from musicbot.slash import playback, playback_options, queue
     playback.register(bot)
+    playback_options.register(bot)
     queue.register(bot)
 
     @bot.tree.error

--- a/musicbot/slash/admin.py
+++ b/musicbot/slash/admin.py
@@ -1,0 +1,496 @@
+"""
+Slash commands — Phase 7: admin.
+/blockuser  /blocksong  /restart  /shutdown  /clean
+/checkupdates  /resetplaylist  /setname  /setnick  /setavatar
+/language  /id  /pldump
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional, Union
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import defer, invoke_response, respond
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+
+log = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ #
+#  Shutdown confirmation view                                          #
+# ------------------------------------------------------------------ #
+
+class ShutdownConfirmView(discord.ui.View):
+    """Requires the owner to confirm before shutting the bot down."""
+
+    def __init__(self, bot: "MusicBot", guild: discord.Guild) -> None:
+        super().__init__(timeout=30)
+        self.bot = bot
+        self.guild = guild
+
+    @discord.ui.button(label="Confirm Shutdown", style=discord.ButtonStyle.danger)
+    async def confirm(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await interaction.response.edit_message(
+            content="Shutting down. Goodbye! \N{WAVING HAND SIGN}", view=None
+        )
+        player = self.bot.get_player_in(self.guild)
+        if player and player.is_paused:
+            player.resume()
+        await self.bot.disconnect_all_voice_clients()
+        raise exceptions.TerminateSignal()
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await interaction.response.edit_message(content="Shutdown cancelled.", view=None)
+
+
+# ------------------------------------------------------------------ #
+#  Registration                                                        #
+# ------------------------------------------------------------------ #
+
+def register(bot: "MusicBot") -> None:
+    """Register all admin slash commands with the bot's CommandTree."""
+
+    # ---------------------------------------------------------------- #
+    #  /blockuser                                                        #
+    # ---------------------------------------------------------------- #
+
+    blockuser_group = app_commands.Group(
+        name="blockuser",
+        description="Manage the user block list.",
+    )
+
+    @blockuser_group.command(
+        name="add", description="Block a user from using DJ Roomba."
+    )
+    @app_commands.describe(user="The member to block.")
+    async def blockuser_add(
+        interaction: discord.Interaction, user: discord.Member
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("blockuser")
+        if user.id == bot.config.owner_id:
+            raise exceptions.CommandError("The owner cannot be added to the block list.")
+        if bot.config.user_blocklist.is_blocked(user):
+            raise exceptions.CommandError(f"**{user.name}** is already blocked.")
+        bot.config.user_blocklist.add_item(str(user.id))
+        await respond(interaction, f"Blocked **{user.name}** from using DJ Roomba.", ephemeral=True)
+
+    @blockuser_group.command(
+        name="remove", description="Unblock a user."
+    )
+    @app_commands.describe(user="The member to unblock.")
+    async def blockuser_remove(
+        interaction: discord.Interaction, user: discord.Member
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("blockuser")
+        if not bot.config.user_blocklist.is_blocked(user):
+            raise exceptions.CommandError(f"**{user.name}** is not in the block list.")
+        bot.config.user_blocklist.remove_item(str(user.id))
+        await respond(interaction, f"Unblocked **{user.name}**.", ephemeral=True)
+
+    @blockuser_group.command(
+        name="status", description="Check whether a user is blocked."
+    )
+    @app_commands.describe(user="The member to check.")
+    async def blockuser_status(
+        interaction: discord.Interaction, user: discord.Member
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("blockuser")
+        blocked = bot.config.user_blocklist.is_blocked(user)
+        status = "**is** blocked" if blocked else "is **not** blocked"
+        await respond(interaction, f"**{user.name}** {status}.", ephemeral=True)
+
+    bot.tree.add_command(blockuser_group)
+
+    # ---------------------------------------------------------------- #
+    #  /blocksong                                                        #
+    # ---------------------------------------------------------------- #
+
+    blocksong_group = app_commands.Group(
+        name="blocksong",
+        description="Manage the song block list.",
+    )
+
+    @blocksong_group.command(
+        name="add",
+        description="Block a song URL or title keyword. Omit to block the current song.",
+    )
+    @app_commands.describe(subject="URL or title keyword to block.")
+    async def blocksong_add(
+        interaction: discord.Interaction, subject: Optional[str] = None
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("blocksong")
+        guild = ctx.require_guild()
+        _player = ctx.get_player_in()
+
+        song_subject = subject or ""
+        response = await bot.cmd_blocksong(
+            ssd_=ctx.ssd,
+            guild=guild,
+            _player=_player,
+            option="add",
+            leftover_args=[],
+            song_subject=song_subject,
+        )
+        await invoke_response(interaction, response)
+
+    @blocksong_group.command(
+        name="remove",
+        description="Remove a song URL or keyword from the block list.",
+    )
+    @app_commands.describe(subject="URL or title keyword to unblock.")
+    async def blocksong_remove(
+        interaction: discord.Interaction, subject: Optional[str] = None
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("blocksong")
+        guild = ctx.require_guild()
+        _player = ctx.get_player_in()
+
+        song_subject = subject or ""
+        response = await bot.cmd_blocksong(
+            ssd_=ctx.ssd,
+            guild=guild,
+            _player=_player,
+            option="remove",
+            leftover_args=[],
+            song_subject=song_subject,
+        )
+        await invoke_response(interaction, response)
+
+    bot.tree.add_command(blocksong_group)
+
+    # ---------------------------------------------------------------- #
+    #  /restart                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="restart",
+        description="Restart DJ Roomba.",
+    )
+    @app_commands.describe(mode="How to restart. Default: soft (reload without process restart).")
+    @app_commands.choices(mode=[
+        app_commands.Choice(name="Soft — reload without process restart (default)", value="soft"),
+        app_commands.Choice(name="Full — restart the entire process",               value="full"),
+        app_commands.Choice(name="Upgrade — update everything then restart",        value="upgrade"),
+        app_commands.Choice(name="Upgit — update source code then restart",         value="upgit"),
+        app_commands.Choice(name="Uppip — update pip packages then restart",        value="uppip"),
+    ])
+    async def slash_restart(
+        interaction: discord.Interaction,
+        mode: Optional[app_commands.Choice[str]] = None,
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("restart")
+        guild = ctx.require_guild()
+
+        opt = mode.value if mode else "soft"
+        _player = ctx.get_player_in()
+
+        await respond(interaction, f"Restarting (`{opt}`)...")
+
+        if _player and _player.is_paused:
+            _player.resume()
+        await bot.disconnect_all_voice_clients()
+
+        restart_codes = {
+            "soft":    exceptions.RestartCode.RESTART_SOFT,
+            "full":    exceptions.RestartCode.RESTART_FULL,
+            "upgrade": exceptions.RestartCode.RESTART_UPGRADE_ALL,
+            "uppip":   exceptions.RestartCode.RESTART_UPGRADE_PIP,
+            "upgit":   exceptions.RestartCode.RESTART_UPGRADE_GIT,
+        }
+        raise exceptions.RestartSignal(code=restart_codes[opt])
+
+    # ---------------------------------------------------------------- #
+    #  /shutdown                                                         #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="shutdown",
+        description="Shut down DJ Roomba completely.",
+    )
+    async def slash_shutdown(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("shutdown")
+        guild = ctx.require_guild()
+
+        view = ShutdownConfirmView(bot, guild)
+        await interaction.response.send_message(
+            "Are you sure you want to shut down DJ Roomba?",
+            view=view,
+            ephemeral=True,
+        )
+
+    # ---------------------------------------------------------------- #
+    #  /clean                                                            #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="clean",
+        description="Remove DJ Roomba messages and command invocations from this channel.",
+    )
+    @app_commands.describe(count="Number of messages to search through (default 50, max 500).")
+    async def slash_clean(
+        interaction: discord.Interaction, count: int = 50
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("clean")
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError("This command requires you to be in a server.")
+
+        # Acknowledge before purging since purge can take a moment.
+        await interaction.response.defer(ephemeral=True)
+
+        search_range = min(abs(count), 500)
+        prefix_list = bot.server_data[guild.id].command_prefix_list
+
+        def is_command_invoke(msg: discord.Message) -> bool:
+            for prefix in prefix_list:
+                if msg.content.startswith(prefix) and msg.content[len(prefix):].strip():
+                    return True
+            return False
+
+        delete_all = (
+            interaction.channel.permissions_for(ctx.author).manage_messages
+            or bot.config.owner_id == ctx.author.id
+        )
+
+        def check(msg: discord.Message) -> bool:
+            if is_command_invoke(msg):
+                return delete_all or msg.author == ctx.author
+            return msg.author == bot.user
+
+        if isinstance(interaction.channel, (discord.TextChannel, discord.Thread)):
+            deleted = await interaction.channel.purge(limit=search_range, check=check)
+            await interaction.followup.send(
+                f"Deleted {len(deleted)} message(s).", ephemeral=True
+            )
+        else:
+            raise exceptions.CommandError("Cannot clean messages in this channel type.")
+
+    # ---------------------------------------------------------------- #
+    #  /checkupdates                                                     #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="checkupdates",
+        description="Check for DJ Roomba and dependency updates.",
+    )
+    async def slash_checkupdates(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("checkupdates")
+
+        await defer(interaction)
+        response = await bot.cmd_checkupdates(
+            ssd_=ctx.ssd, channel=interaction.channel
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /resetplaylist                                                    #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="resetplaylist",
+        description="Reset the auto playlist back to its default tracks.",
+    )
+    async def slash_resetplaylist(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("resetplaylist")
+        guild = ctx.require_guild()
+        player = await ctx.get_player()
+        response = await bot.cmd_resetplaylist(
+            ssd_=ctx.ssd, guild=guild, player=player
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /setname                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="setname",
+        description="Change DJ Roomba's Discord username.",
+    )
+    @app_commands.describe(name="New username.")
+    async def slash_setname(interaction: discord.Interaction, name: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("setname")
+        response = await bot.cmd_setname(
+            ssd_=ctx.ssd, leftover_args=[], name=name
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /setnick                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="setnick",
+        description="Change DJ Roomba's nickname in this server.",
+    )
+    @app_commands.describe(nick="New server nickname.")
+    async def slash_setnick(interaction: discord.Interaction, nick: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("setnick")
+        guild = ctx.require_guild()
+        response = await bot.cmd_setnick(
+            ssd_=ctx.ssd,
+            guild=guild,
+            channel=interaction.channel,
+            leftover_args=[],
+            nick=nick,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /setavatar                                                        #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="setavatar",
+        description="Change DJ Roomba's avatar to an image URL.",
+    )
+    @app_commands.describe(url="Direct URL to the new avatar image.")
+    async def slash_setavatar(interaction: discord.Interaction, url: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("setavatar")
+
+        await defer(interaction)
+
+        import aiohttp
+        try:
+            async with bot.session.get(url) as resp:
+                if resp.status != 200:
+                    raise exceptions.CommandError("Could not fetch image from that URL.")
+                data = await resp.read()
+            if bot.user:
+                await bot.user.edit(avatar=data)
+        except exceptions.CommandError:
+            raise
+        except Exception as e:
+            raise exceptions.CommandError(
+                "Failed to change avatar: %(error)s",
+                fmt_args={"error": str(e)},
+            ) from e
+
+        await respond(interaction, "Changed the bot's avatar.")
+
+    # ---------------------------------------------------------------- #
+    #  /language                                                         #
+    # ---------------------------------------------------------------- #
+
+    language_group = app_commands.Group(
+        name="language",
+        description="Manage the language used for bot messages in this server.",
+    )
+
+    @language_group.command(
+        name="show", description="Show the current language and available options."
+    )
+    async def language_show(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("language")
+        response = await bot.cmd_language(ssd_=ctx.ssd, subcmd="show")
+        await invoke_response(interaction, response)
+
+    @language_group.command(name="set", description="Set the server language.")
+    @app_commands.describe(code="Language locale code, e.g. en_US.")
+    async def language_set(interaction: discord.Interaction, code: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("language")
+        response = await bot.cmd_language(ssd_=ctx.ssd, subcmd="set", lang_code=code)
+        await invoke_response(interaction, response)
+
+    @language_group.command(
+        name="reset", description="Reset the server language to the bot default."
+    )
+    async def language_reset(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("language")
+        response = await bot.cmd_language(ssd_=ctx.ssd, subcmd="reset")
+        await invoke_response(interaction, response)
+
+    bot.tree.add_command(language_group)
+
+    # ---------------------------------------------------------------- #
+    #  /id                                                               #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="id",
+        description="Show the Discord ID of a user or channel.",
+    )
+    @app_commands.describe(
+        user="User to look up.",
+        channel="Channel to look up.",
+    )
+    async def slash_id(
+        interaction: discord.Interaction,
+        user: Optional[discord.Member] = None,
+        channel: Optional[Union[discord.TextChannel, discord.VoiceChannel]] = None,
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("id")
+
+        if user:
+            await respond(
+                interaction,
+                f"ID for **{user.name}**: `{user.id}`",
+                ephemeral=True,
+            )
+        elif channel:
+            await respond(
+                interaction,
+                f"ID for **#{channel.name}**: `{channel.id}`",
+                ephemeral=True,
+            )
+        else:
+            await respond(
+                interaction,
+                f"Your ID: `{interaction.user.id}`",
+                ephemeral=True,
+            )
+
+    # ---------------------------------------------------------------- #
+    #  /pldump                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="pldump",
+        description="Save the current queue to a playlist file.",
+    )
+    async def slash_pldump(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("pldump")
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError("This command requires you to be in a server.")
+
+        player = await ctx.get_player()
+        response = await bot.cmd_pldump(
+            ssd_=ctx.ssd,
+            channel=interaction.channel,
+            guild=guild,
+            author=ctx.author,
+            player=player,
+        )
+        await invoke_response(interaction, response)

--- a/musicbot/slash/context.py
+++ b/musicbot/slash/context.py
@@ -1,0 +1,78 @@
+"""
+SlashContext: wraps discord.Interaction to provide the same context
+objects (guild, author, player, permissions) that cmd_ methods use.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
+
+import discord
+
+from musicbot import exceptions
+from musicbot.permissions import PermissionGroup
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+    from musicbot.constructs import GuildSpecificData
+    from musicbot.player import MusicPlayer
+
+
+class SlashContext:
+    """
+    Provides guild, author, channel, permissions, and player access
+    for a slash command interaction — mirroring the injected parameters
+    that cmd_ methods receive from the prefix command dispatcher.
+    """
+
+    def __init__(self, interaction: discord.Interaction, bot: "MusicBot") -> None:
+        self.interaction = interaction
+        self.bot = bot
+        self.guild: Optional[discord.Guild] = interaction.guild
+        self.author: Union[discord.Member, discord.User] = interaction.user
+        self.channel = interaction.channel
+        self.ssd: Optional[GuildSpecificData] = (
+            bot.server_data[interaction.guild.id] if interaction.guild else None
+        )
+        self.permissions: PermissionGroup = bot.permissions.for_user(interaction.user)
+
+    def check_permission(self, command: str, sub: str = "") -> None:
+        """Raise PermissionsError if the user cannot use this command."""
+        if self.author.id == self.bot.config.owner_id:
+            return
+        if not self.permissions.can_use_command(command, sub):
+            raise exceptions.PermissionsError(
+                "This command is not allowed for your permissions group:  %(group)s",
+                fmt_args={"group": self.permissions.name},
+            )
+
+    def require_guild(self) -> discord.Guild:
+        """Return the guild or raise CommandError if not in a server."""
+        if not self.guild:
+            raise exceptions.CommandError(
+                "This command can only be used in a server."
+            )
+        return self.guild
+
+    def get_player_in(self) -> Optional["MusicPlayer"]:
+        """Return the active player for this guild without creating one."""
+        if self.guild:
+            return self.bot.get_player_in(self.guild)
+        return None
+
+    async def get_player(self, create: bool = False) -> "MusicPlayer":
+        """
+        Return the guild's music player, creating one if needed.
+        Raises CommandError if the user is not in a voice channel.
+        """
+        if not self.guild or not isinstance(self.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+        if not self.author.voice or not self.author.voice.channel:
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+        return await self.bot.get_player(
+            self.author.voice.channel,
+            create=create or self.permissions.summonplay,
+        )

--- a/musicbot/slash/control.py
+++ b/musicbot/slash/control.py
@@ -1,0 +1,162 @@
+"""
+Slash commands — Phase 5: bot control.
+/summon  /disconnect  /reconnect  /follow  /karaoke
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import invoke_response, respond
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+
+log = logging.getLogger(__name__)
+
+
+def register(bot: "MusicBot") -> None:
+    """Register all bot-control slash commands with the bot's CommandTree."""
+
+    # ---------------------------------------------------------------- #
+    #  /summon                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="summon",
+        description="Bring DJ Roomba to the voice channel you're in.",
+    )
+    async def slash_summon(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("summon")
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member) or not ctx.author.voice or not ctx.author.voice.channel:
+            raise exceptions.CommandError(
+                "You are not connected to a voice channel."
+            )
+
+        # Call cmd_summon with message=None — last_np_msg will be cleared,
+        # which is fine since slash commands don't produce a message object.
+        response = await bot.cmd_summon(
+            ssd_=ctx.ssd,
+            guild=guild,
+            author=ctx.author,
+            message=None,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /disconnect                                                       #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="disconnect",
+        description="Disconnect DJ Roomba from the voice channel.",
+    )
+    async def slash_disconnect(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("disconnect")
+        guild = ctx.require_guild()
+        response = await bot.cmd_disconnect(guild=guild)
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /reconnect                                                        #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="reconnect",
+        description="Disconnect and reconnect to voice, preserving the queue.",
+    )
+    async def slash_reconnect(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("reconnect")
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a server."
+            )
+
+        response = await bot.cmd_reconnect(
+            ssd_=ctx.ssd,
+            guild=guild,
+            author=ctx.author,
+            channel=interaction.channel,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /follow                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="follow",
+        description="Have DJ Roomba follow you (or another user) between voice channels.",
+    )
+    @app_commands.describe(
+        user="User to follow. Owner only. Leave blank to follow yourself."
+    )
+    async def slash_follow(
+        interaction: discord.Interaction,
+        user: Optional[discord.Member] = None,
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("follow")
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a server."
+            )
+
+        followed_user = bot.server_data[guild.id].follow_user
+
+        # If already following, toggle off or switch.
+        if followed_user is not None:
+            if followed_user.id == ctx.author.id:
+                bot.server_data[guild.id].follow_user = None
+                await respond(
+                    interaction,
+                    f"No longer following `{ctx.author.name}`.",
+                )
+                return
+
+            bot.server_data[guild.id].follow_user = ctx.author
+            await respond(
+                interaction,
+                f"Now following `{ctx.author.name}` between voice channels.",
+            )
+            return
+
+        # Owner can target another member; everyone else follows themselves.
+        target = ctx.author
+        if ctx.author.id == bot.config.owner_id and user is not None:
+            target = user
+
+        bot.server_data[guild.id].follow_user = target
+        await respond(
+            interaction,
+            f"Will follow `{target.name}` between voice channels.",
+        )
+
+    # ---------------------------------------------------------------- #
+    #  /karaoke                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="karaoke",
+        description="Toggle karaoke mode — only members with bypass permission can queue songs.",
+    )
+    async def slash_karaoke(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("karaoke")
+        player = await ctx.get_player()
+        response = await bot.cmd_karaoke(ssd_=ctx.ssd, player=player)
+        await invoke_response(interaction, response)

--- a/musicbot/slash/control.py
+++ b/musicbot/slash/control.py
@@ -12,7 +12,7 @@ from discord import app_commands
 
 from musicbot import exceptions
 from musicbot.slash.context import SlashContext
-from musicbot.slash.responses import invoke_response, respond
+from musicbot.slash.responses import defer, invoke_response, respond
 
 if TYPE_CHECKING:
     from musicbot.bot import MusicBot
@@ -63,6 +63,7 @@ def register(bot: "MusicBot") -> None:
         ctx = SlashContext(interaction, bot)
         ctx.check_permission("disconnect")
         guild = ctx.require_guild()
+        await defer(interaction)
         response = await bot.cmd_disconnect(guild=guild)
         await invoke_response(interaction, response)
 
@@ -84,6 +85,7 @@ def register(bot: "MusicBot") -> None:
                 "This command requires you to be in a server."
             )
 
+        await defer(interaction)
         response = await bot.cmd_reconnect(
             ssd_=ctx.ssd,
             guild=guild,

--- a/musicbot/slash/enhancements.py
+++ b/musicbot/slash/enhancements.py
@@ -1,0 +1,264 @@
+"""
+Slash commands — Phase 8: enhancements and remaining commands.
+"Add to Queue" message context menu, /stream, /autoplaylist group.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Optional
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import defer, invoke_response, respond
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+
+log = logging.getLogger(__name__)
+
+_URL_RE = re.compile(r"https?://\S+")
+
+
+# ------------------------------------------------------------------ #
+#  Registration                                                        #
+# ------------------------------------------------------------------ #
+
+def register(bot: "MusicBot") -> None:
+    """Register Phase 8 enhancements with the bot's CommandTree."""
+
+    # ---------------------------------------------------------------- #
+    #  "Add to Queue" message context menu                              #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.context_menu(name="Add to Queue")
+    async def add_to_queue_ctx(
+        interaction: discord.Interaction, message: discord.Message
+    ) -> None:
+        """Right-click any message → Apps → Add to Queue."""
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("play")
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a server."
+            )
+
+        # Extract the first URL from the message.
+        match = _URL_RE.search(message.content)
+        if not match:
+            await interaction.response.send_message(
+                "No URL found in that message.", ephemeral=True
+            )
+            return
+
+        url = match.group(0).rstrip(".,;!?)")  # strip common trailing punctuation
+        guild = ctx.require_guild()
+
+        await defer(interaction)
+        player = await ctx.get_player(create=True)
+
+        response = await bot._cmd_play(
+            None,
+            player,
+            interaction.channel,
+            guild,
+            ctx.author,
+            ctx.permissions,
+            [],
+            url,
+            head=False,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /stream                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="stream",
+        description="Stream a live URL directly without downloading (Twitch, radio, etc.).",
+    )
+    @app_commands.describe(url="Stream URL to add to the queue.")
+    async def slash_stream(interaction: discord.Interaction, url: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("stream")
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        await defer(interaction)
+
+        player = await ctx.get_player(create=True)
+
+        if (
+            ctx.permissions.max_songs
+            and player.playlist.count_for_user(ctx.author) >= ctx.permissions.max_songs
+        ):
+            raise exceptions.PermissionsError(
+                "You have reached your enqueued song limit (%(max)s)",
+                fmt_args={"max": ctx.permissions.max_songs},
+            )
+
+        if player.karaoke_mode and not ctx.permissions.bypass_karaoke_mode:
+            raise exceptions.PermissionsError(
+                "Karaoke mode is enabled, please try again when it's disabled."
+            )
+
+        try:
+            info = await bot.downloader.extract_info(
+                url, download=False, process=True, as_stream=True
+            )
+        except Exception as e:
+            log.exception("Failed to get info from stream: %s", url)
+            raise exceptions.CommandError(
+                "Failed to extract stream info: %(error)s",
+                fmt_args={"error": str(e)},
+            ) from e
+
+        if info.has_entries:
+            raise exceptions.CommandError("Streaming playlists is not supported.")
+
+        bot._do_song_blocklist_check(info.url)
+        if info.url != info.title:
+            bot._do_song_blocklist_check(info.title)
+
+        await player.playlist.add_stream_from_info(
+            info,
+            channel=interaction.channel,
+            author=ctx.author,
+            head=False,
+        )
+
+        if player.is_stopped:
+            player.play()
+
+        await respond(
+            interaction,
+            f"Connected to the stream. **{info.title}**\n\nEnd the stream with `/skip`.",
+        )
+
+    # ---------------------------------------------------------------- #
+    #  /autoplaylist                                                     #
+    # ---------------------------------------------------------------- #
+
+    apl_group = app_commands.Group(
+        name="autoplaylist",
+        description="Manage the auto playlist that plays when the queue is empty.",
+    )
+
+    @apl_group.command(
+        name="add",
+        description="Add a URL to the auto playlist. Omit to add the current song.",
+    )
+    @app_commands.describe(url="URL to add. Leave blank to add the currently playing song.")
+    async def apl_add(
+        interaction: discord.Interaction, url: Optional[str] = None
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("autoplaylist")
+        guild = ctx.require_guild()
+
+        track_url = url
+        if not track_url:
+            _player = ctx.get_player_in()
+            if not _player or not _player.current_entry:
+                raise exceptions.CommandError(
+                    "No song is currently playing. Provide a URL to add."
+                )
+            track_url = _player.current_entry.url
+
+        valid = bot.downloader.get_url_or_none(track_url)
+        if not valid:
+            raise exceptions.CommandError("That doesn't look like a valid URL.")
+
+        bot._do_song_blocklist_check(valid)
+
+        apl = bot.server_data[guild.id].autoplaylist
+        if valid in apl:
+            raise exceptions.CommandError("That song is already in the auto playlist.")
+
+        await apl.add_track(valid)
+        await respond(interaction, f"Added `{valid}` to the auto playlist.")
+
+    @apl_group.command(
+        name="remove",
+        description="Remove a URL from the auto playlist. Omit to remove the current song.",
+    )
+    @app_commands.describe(url="URL to remove. Leave blank to remove the currently playing song.")
+    async def apl_remove(
+        interaction: discord.Interaction, url: Optional[str] = None
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("autoplaylist")
+        guild = ctx.require_guild()
+
+        track_url = url
+        if not track_url:
+            _player = ctx.get_player_in()
+            if not _player or not _player.current_entry:
+                raise exceptions.CommandError(
+                    "No song is currently playing. Provide a URL to remove."
+                )
+            track_url = _player.current_entry.url
+
+        apl = bot.server_data[guild.id].autoplaylist
+        if track_url not in apl:
+            raise exceptions.CommandError("That song is not in the auto playlist.")
+
+        await apl.remove_track(
+            track_url,
+            ex=UserWarning(f"Removed via slash command by {ctx.author.id}/{ctx.author.name}"),
+            delete_from_ap=True,
+        )
+        await respond(interaction, f"Removed `{track_url}` from the auto playlist.")
+
+    @apl_group.command(
+        name="show",
+        description="Show the current auto playlist and all available playlists.",
+    )
+    async def apl_show(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("autoplaylist")
+
+        response = await bot.cmd_autoplaylist(
+            ssd_=ctx.ssd,
+            guild=ctx.require_guild(),
+            author=ctx.author,
+            channel=interaction.channel,
+            voice_channel=None,
+            message=None,
+            _player=ctx.get_player_in(),
+            player=ctx.get_player_in(),
+            option="show",
+            opt_url="",
+        )
+        await invoke_response(interaction, response)
+
+    @apl_group.command(
+        name="restart",
+        description="Reload the auto playlist from disk and refresh the player queue.",
+    )
+    async def apl_restart(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("autoplaylist")
+        guild = ctx.require_guild()
+
+        apl = bot.server_data[guild.id].autoplaylist
+        await apl.load(force=True)
+
+        _player = ctx.get_player_in()
+        if _player:
+            _player.autoplaylist = list(apl)
+
+        await respond(
+            interaction,
+            f"Reloaded auto playlist from `{apl.filename}`.",
+        )
+
+    bot.tree.add_command(apl_group)

--- a/musicbot/slash/playback.py
+++ b/musicbot/slash/playback.py
@@ -1,0 +1,256 @@
+"""
+Slash commands — Phase 2: core playback.
+/play  /pause  /resume  /stop  /skip  /volume
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import defer, invoke_response, respond, respond_error
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+
+log = logging.getLogger(__name__)
+
+
+def register(bot: "MusicBot") -> None:
+    """Register all playback slash commands with the bot's CommandTree."""
+
+    # ------------------------------------------------------------------ #
+    #  /play                                                               #
+    # ------------------------------------------------------------------ #
+
+    @bot.tree.command(
+        name="play",
+        description="Add a song or playlist to the queue. Accepts URLs or search terms.",
+    )
+    @app_commands.describe(query="Song name, URL, or playlist link")
+    async def slash_play(interaction: discord.Interaction, query: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("play")
+
+        # Defer immediately — extraction and download can take several seconds.
+        await defer(interaction)
+
+        guild = ctx.require_guild()
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player(create=True)
+        channel = interaction.channel
+
+        # Replicate auto-unpause behaviour from _do_cmd_unpause_check.
+        if bot.config.auto_unpause_on_play and player.is_paused:
+            player.resume()
+            await respond(interaction, "Bot was previously paused, resuming playback now.")
+            return
+
+        response = await bot._cmd_play(
+            None,           # message — not needed for slash commands
+            player,
+            channel,
+            guild,
+            ctx.author,
+            ctx.permissions,
+            [],             # leftover_args
+            query,
+            head=False,
+        )
+        await invoke_response(interaction, response)
+
+    # ------------------------------------------------------------------ #
+    #  /pause                                                              #
+    # ------------------------------------------------------------------ #
+
+    @bot.tree.command(name="pause", description="Pause the currently playing song.")
+    async def slash_pause(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("pause")
+        player = await ctx.get_player()
+        response = await bot.cmd_pause(ssd_=ctx.ssd, player=player)
+        await invoke_response(interaction, response)
+
+    # ------------------------------------------------------------------ #
+    #  /resume                                                             #
+    # ------------------------------------------------------------------ #
+
+    @bot.tree.command(name="resume", description="Resume paused playback.")
+    async def slash_resume(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("resume")
+        player = await ctx.get_player()
+        response = await bot.cmd_resume(ssd_=ctx.ssd, player=player)
+        await invoke_response(interaction, response)
+
+    # ------------------------------------------------------------------ #
+    #  /stop                                                               #
+    # ------------------------------------------------------------------ #
+
+    @bot.tree.command(
+        name="stop",
+        description="Stop playback and clear the entire queue.",
+    )
+    async def slash_stop(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("stop")
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player()
+
+        if not player.is_playing:
+            raise exceptions.CommandError("I'm not playing anything right now.")
+
+        player.skip()
+        player.playlist.clear()
+
+        await respond(
+            interaction,
+            f"Stopped playback and cleared the queue in `{player.voice_client.channel.name}`.\n"
+            "Start a new session with `/play`.",
+        )
+
+    # ------------------------------------------------------------------ #
+    #  /skip                                                               #
+    # ------------------------------------------------------------------ #
+
+    @bot.tree.command(
+        name="skip",
+        description="Skip or vote to skip the current song.",
+    )
+    @app_commands.describe(force="Force skip without a vote (requires InstaSkip permission).")
+    async def slash_skip(
+        interaction: discord.Interaction, force: bool = False
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("skip")
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player()
+        ssd = ctx.ssd
+
+        if player.is_stopped:
+            raise exceptions.CommandError("I'm not playing anything to skip.")
+
+        if not player.current_entry:
+            next_entry = player.playlist.peek()
+            if next_entry:
+                if next_entry.is_downloading:
+                    raise exceptions.CommandError(
+                        f"**{next_entry.title}** is still downloading, please wait."
+                    )
+                if next_entry.is_downloaded:
+                    raise exceptions.CommandError(
+                        "The next song will be played shortly. Please wait."
+                    )
+            raise exceptions.CommandError(
+                "Something odd is happening. Try restarting the bot if this persists."
+            )
+
+        current_entry = player.current_entry
+        entry_author_id = current_entry.author.id if current_entry.author else 0
+
+        permission_force_skip = ctx.permissions.instaskip or (
+            bot.config.allow_author_skip and ctx.author.id == entry_author_id
+        )
+
+        if permission_force_skip and (force or bot.config.legacy_skip):
+            if not ctx.permissions.skip_looped and player.repeatsong:
+                raise exceptions.PermissionsError(
+                    "You do not have permission to force skip a looped song."
+                )
+
+            guild = ctx.require_guild()
+            if (
+                bot.config.enable_queue_history_global
+                or bot.config.enable_queue_history_guilds
+            ):
+                bot.server_data[guild.id].current_playing_url = ""
+
+            if player.repeatsong:
+                player.repeatsong = False
+            player.skip()
+            await respond(
+                interaction, f"Force skipped **{current_entry.title}**."
+            )
+            return
+
+        if not permission_force_skip and force:
+            raise exceptions.PermissionsError(
+                "You do not have permission to force skip."
+            )
+
+        # Vote skip — track by user ID only (no message reference for slash commands).
+        voice_channel = player.voice_client.channel
+        num_voice = sum(
+            1
+            for m in voice_channel.members
+            if not m.bot and not m.voice.deaf and not m.voice.self_deaf
+        ) or 1
+
+        player.skip_state.skippers.add(ctx.author.id)
+        num_skips = sum(
+            1
+            for m in voice_channel.members
+            if m.id in player.skip_state.skippers
+        )
+
+        skips_required = min(
+            bot.config.skips_required,
+            round(num_voice * bot.config.skip_ratio_required),
+        )
+
+        if num_skips >= skips_required:
+            if player.repeatsong:
+                player.repeatsong = False
+            player.skip()
+            await respond(
+                interaction,
+                f"Skipped **{current_entry.title}** — enough votes to skip "
+                f"({num_skips}/{skips_required}).",
+            )
+        else:
+            skips_remaining = skips_required - num_skips
+            await respond(
+                interaction,
+                f"Your vote to skip **{current_entry.title}** has been added.\n"
+                f"{skips_remaining} more vote(s) needed.",
+            )
+
+    # ------------------------------------------------------------------ #
+    #  /volume                                                             #
+    # ------------------------------------------------------------------ #
+
+    @bot.tree.command(
+        name="volume",
+        description="Set the playback volume (1–100), or check the current level.",
+    )
+    @app_commands.describe(level="Volume level from 1 to 100. Leave blank to check.")
+    async def slash_volume(
+        interaction: discord.Interaction, level: Optional[int] = None
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("volume")
+        player = await ctx.get_player()
+
+        new_volume = "" if level is None else str(level)
+        response = await bot.cmd_volume(
+            ssd_=ctx.ssd, player=player, new_volume=new_volume
+        )
+        await invoke_response(interaction, response)

--- a/musicbot/slash/playback_options.py
+++ b/musicbot/slash/playback_options.py
@@ -13,7 +13,7 @@ from discord import app_commands
 from musicbot import exceptions
 from musicbot.constants import MUSICBOT_EMBED_COLOR_NORMAL
 from musicbot.slash.context import SlashContext
-from musicbot.slash.responses import defer, invoke_response, respond
+from musicbot.slash.responses import defer, invoke_response, respond, schedule_delete
 from musicbot.utils import format_song_duration
 
 if TYPE_CHECKING:
@@ -100,6 +100,9 @@ class SearchView(discord.ui.View):
             color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_NORMAL),
         )
         await interaction.message.edit(embed=result_embed, view=None)
+        cfg = getattr(interaction.client, "config", None)
+        if cfg is not None and getattr(cfg, "delete_messages", False):
+            schedule_delete(interaction.message, cfg.delete_delay_short)
 
 
 # ------------------------------------------------------------------ #

--- a/musicbot/slash/playback_options.py
+++ b/musicbot/slash/playback_options.py
@@ -52,6 +52,7 @@ class SearchView(discord.ui.View):
         self.guild = guild
         self.author = author
         self.permissions = permissions
+        self.message: Optional[discord.Message] = None
 
         options = []
         for i, entry in enumerate(entries[:25], 1):
@@ -66,6 +67,14 @@ class SearchView(discord.ui.View):
 
     async def on_timeout(self) -> None:
         self.result_select.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except discord.HTTPException:
+                pass
+            cfg = getattr(self.bot, "config", None)
+            if cfg is not None and getattr(cfg, "delete_messages", False):
+                schedule_delete(self.message, cfg.delete_delay_short)
 
     @discord.ui.select(placeholder="Pick a result to add it to the queue...")
     async def result_select(
@@ -380,4 +389,5 @@ def register(bot: "MusicBot") -> None:
             permissions=ctx.permissions,
         )
 
-        await interaction.followup.send(embed=embed, view=view)
+        msg = await interaction.followup.send(embed=embed, view=view, wait=True)
+        view.message = msg

--- a/musicbot/slash/playback_options.py
+++ b/musicbot/slash/playback_options.py
@@ -1,0 +1,380 @@
+"""
+Slash commands — Phase 4: playback options.
+/repeat  /seek  /speed  /playnow  /playnext  /shuffleplay  /search
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List, Optional
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.constants import MUSICBOT_EMBED_COLOR_NORMAL
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import defer, invoke_response, respond
+from musicbot.utils import format_song_duration
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+    from musicbot.player import MusicPlayer
+    from musicbot.permissions import PermissionGroup
+
+log = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ #
+#  Search results select menu                                          #
+# ------------------------------------------------------------------ #
+
+class SearchView(discord.ui.View):
+    """
+    Presents search results as a Select dropdown.
+    The invoking user picks a result and it is added to the queue.
+    """
+
+    def __init__(
+        self,
+        bot: "MusicBot",
+        player: "MusicPlayer",
+        entries: list,
+        channel: discord.abc.Messageable,
+        guild: discord.Guild,
+        author: discord.Member,
+        permissions: "PermissionGroup",
+    ) -> None:
+        super().__init__(timeout=60)
+        self.bot = bot
+        self.player = player
+        self.entries = entries
+        self.channel = channel
+        self.guild = guild
+        self.author = author
+        self.permissions = permissions
+
+        options = []
+        for i, entry in enumerate(entries[:25], 1):
+            title = entry.get("title", "Unknown")
+            label = f"{i}. {title}"[:100]
+            duration = format_song_duration(entry.duration_td)
+            options.append(
+                discord.SelectOption(label=label, description=duration, value=str(i - 1))
+            )
+
+        self.result_select.options = options
+
+    async def on_timeout(self) -> None:
+        self.result_select.disabled = True
+
+    @discord.ui.select(placeholder="Pick a result to add it to the queue...")
+    async def result_select(
+        self, interaction: discord.Interaction, select: discord.ui.Select
+    ) -> None:
+        if interaction.user.id != self.author.id:
+            await interaction.response.send_message(
+                "Only the person who searched can pick a result.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer()
+
+        entry = self.entries[int(select.values[0])]
+        title = entry.get("title", "Unknown")
+        url = entry.get("url") or entry.get("webpage_url", "")
+
+        await self.bot._cmd_play(
+            None,
+            self.player,
+            self.channel,
+            self.guild,
+            self.author,
+            self.permissions,
+            [],
+            url,
+            head=False,
+        )
+
+        result_embed = discord.Embed(
+            description=f"Added **{title}** to the queue.",
+            color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_NORMAL),
+        )
+        await interaction.message.edit(embed=result_embed, view=None)
+
+
+# ------------------------------------------------------------------ #
+#  Registration                                                        #
+# ------------------------------------------------------------------ #
+
+def register(bot: "MusicBot") -> None:
+    """Register all playback-options slash commands with the bot's CommandTree."""
+
+    # ---------------------------------------------------------------- #
+    #  /repeat                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="repeat",
+        description="Set the repeat mode: off, song, or playlist.",
+    )
+    @app_commands.describe(mode="What to repeat. Omit to cycle through modes.")
+    @app_commands.choices(mode=[
+        app_commands.Choice(name="Off — stop repeating",         value="off"),
+        app_commands.Choice(name="Song — loop the current song", value="song"),
+        app_commands.Choice(name="Playlist — loop the queue",    value="all"),
+    ])
+    async def slash_repeat(
+        interaction: discord.Interaction,
+        mode: Optional[app_commands.Choice[str]] = None,
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("repeat")
+        player = await ctx.get_player()
+
+        option = mode.value if mode else ""
+        response = await bot.cmd_repeat(ssd_=ctx.ssd, player=player, option=option)
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /seek                                                             #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="seek",
+        description="Jump to a position in the current song.",
+    )
+    @app_commands.describe(
+        time='Position to seek to, e.g. "1:30" or "90". Prefix with + or - for relative seek.'
+    )
+    async def slash_seek(interaction: discord.Interaction, time: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("seek")
+        guild = ctx.require_guild()
+        player = await ctx.get_player()
+
+        response = await bot.cmd_seek(
+            ssd_=ctx.ssd,
+            guild=guild,
+            player=player,
+            leftover_args=[],
+            seek_time=time,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /speed                                                            #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="speed",
+        description="Change the playback speed of the current track (0.5–2.0).",
+    )
+    @app_commands.describe(rate="Playback speed multiplier, e.g. 1.5 for 50% faster.")
+    async def slash_speed(interaction: discord.Interaction, rate: float) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("speed")
+        guild = ctx.require_guild()
+        player = await ctx.get_player()
+
+        response = await bot.cmd_speed(
+            ssd_=ctx.ssd,
+            guild=guild,
+            player=player,
+            new_speed=str(rate),
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /playnext                                                         #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="playnext",
+        description="Add a song to the front of the queue so it plays next.",
+    )
+    @app_commands.describe(query="Song name, URL, or playlist link.")
+    async def slash_playnext(interaction: discord.Interaction, query: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("playnext")
+
+        await defer(interaction)
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player(create=True)
+
+        response = await bot._cmd_play(
+            None,
+            player,
+            interaction.channel,
+            guild,
+            ctx.author,
+            ctx.permissions,
+            [],
+            query,
+            head=True,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /playnow                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="playnow",
+        description="Play a song immediately, skipping whatever is currently playing.",
+    )
+    @app_commands.describe(query="Song name, URL, or playlist link.")
+    async def slash_playnow(interaction: discord.Interaction, query: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("playnow")
+
+        await defer(interaction)
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player(create=True)
+
+        response = await bot._cmd_play(
+            None,
+            player,
+            interaction.channel,
+            guild,
+            ctx.author,
+            ctx.permissions,
+            [],
+            query,
+            head=True,
+            skip_playing=True,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /shuffleplay                                                      #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="shuffleplay",
+        description="Add a playlist to the queue and shuffle it immediately.",
+    )
+    @app_commands.describe(query="Playlist URL or search terms.")
+    async def slash_shuffleplay(interaction: discord.Interaction, query: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("shuffleplay")
+
+        await defer(interaction)
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player(create=True)
+
+        response = await bot._cmd_play(
+            None,
+            player,
+            interaction.channel,
+            guild,
+            ctx.author,
+            ctx.permissions,
+            [],
+            query,
+            head=False,
+            shuffle_entries=True,
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /search                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="search",
+        description="Search YouTube and pick a result to add to the queue.",
+    )
+    @app_commands.describe(query="What to search for.")
+    async def slash_search(interaction: discord.Interaction, query: str) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("search")
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        await defer(interaction)
+
+        guild = ctx.require_guild()
+        player = await ctx.get_player(create=True)
+
+        if (
+            ctx.permissions.max_songs
+            and player.playlist.count_for_user(ctx.author) > ctx.permissions.max_songs
+        ):
+            raise exceptions.PermissionsError(
+                "You have reached your playlist item limit (%(max)s)",
+                fmt_args={"max": ctx.permissions.max_songs},
+            )
+
+        if player.karaoke_mode and not ctx.permissions.bypass_karaoke_mode:
+            raise exceptions.PermissionsError(
+                "Karaoke mode is enabled, please try again when it's disabled."
+            )
+
+        bot._do_song_blocklist_check(query)
+
+        num_results = min(
+            bot.config.defaultsearchresults,
+            ctx.permissions.max_search_items,
+        )
+        search_query = f"ytsearch{num_results}:{query}"
+
+        try:
+            info = await bot.downloader.extract_info(
+                search_query, download=False, process=True
+            )
+        except Exception as e:
+            log.warning("Search failed: %s", e)
+            raise exceptions.CommandError(
+                "Search failed. Please try again or use a direct URL with `/play`."
+            ) from e
+
+        if not info:
+            raise exceptions.CommandError("No results found.")
+
+        entries = info.get_entries_objects()
+        if not entries:
+            raise exceptions.CommandError("No results found.")
+
+        embed = discord.Embed(
+            title=f"Search results for: {query}",
+            color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_NORMAL),
+        )
+        lines = []
+        for i, entry in enumerate(entries[:25], 1):
+            title = entry.get("title", "Unknown")
+            duration = format_song_duration(entry.duration_td)
+            lines.append(f"`{i}.` **{title}** `{duration}`")
+        embed.description = "\n".join(lines)
+
+        view = SearchView(
+            bot=bot,
+            player=player,
+            entries=entries[:25],
+            channel=interaction.channel,
+            guild=guild,
+            author=ctx.author,
+            permissions=ctx.permissions,
+        )
+
+        await interaction.followup.send(embed=embed, view=view)

--- a/musicbot/slash/queue.py
+++ b/musicbot/slash/queue.py
@@ -109,6 +109,7 @@ class QueueView(discord.ui.View):
         self.player = player
         self.page = page
         self.pages_total = pages_total
+        self.message: Optional[discord.Message] = None
 
         if pages_total == 0:
             self.prev_btn.disabled = True
@@ -116,11 +117,37 @@ class QueueView(discord.ui.View):
 
     async def _update(self, interaction: discord.Interaction) -> None:
         embed, self.pages_total = _build_queue_embed(self.bot, self.player, self.page)
+        if self.pages_total == 0:
+            self.prev_btn.disabled = True
+            self.next_btn.disabled = True
+        else:
+            self.prev_btn.disabled = False
+            self.next_btn.disabled = False
         await interaction.response.edit_message(embed=embed, view=self)
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,
+    ) -> None:
+        log.exception("QueueView button error", exc_info=error)
+        try:
+            await interaction.response.send_message(
+                "Something went wrong updating the queue. Try `/queue` again.",
+                ephemeral=True,
+            )
+        except discord.HTTPException:
+            pass
 
     async def on_timeout(self) -> None:
         self.prev_btn.disabled = True
         self.next_btn.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except discord.HTTPException:
+                pass
 
     @discord.ui.button(label="◀", style=discord.ButtonStyle.secondary)
     async def prev_btn(
@@ -203,7 +230,8 @@ def register(bot: "MusicBot") -> None:
 
         embed, pages_total = _build_queue_embed(bot, player, page_index)
         view = QueueView(bot, player, page_index, pages_total)
-        await respond_with_embed(interaction, embed, view=view)
+        msg = await respond_with_embed(interaction, embed, view=view)
+        view.message = msg
 
     # ---------------------------------------------------------------- #
     #  /clearqueue                                                       #

--- a/musicbot/slash/queue.py
+++ b/musicbot/slash/queue.py
@@ -1,0 +1,356 @@
+"""
+Slash commands — Phase 3: queue management.
+/queue list  /queue clear  /queue shuffle  /queue remove
+/promote  /move
+"""
+from __future__ import annotations
+
+import logging
+import math
+from collections import deque
+from typing import TYPE_CHECKING, List, Optional
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.constants import MUSICBOT_EMBED_COLOR_NORMAL
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import defer, invoke_response, respond, respond_with_embed
+from musicbot.utils import format_song_duration
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+    from musicbot.player import MusicPlayer
+
+log = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ #
+#  Queue embed builder                                                 #
+# ------------------------------------------------------------------ #
+
+def _build_queue_embed(
+    bot: "MusicBot",
+    player: "MusicPlayer",
+    page: int,
+) -> tuple[discord.Embed, int]:
+    """
+    Build the queue embed for a given page number.
+    Returns (embed, pages_total) where pages_total is the max page index.
+    """
+    total = len(player.playlist.entries)
+    pages_total = math.ceil(total / bot.config.queue_length) - 1 if total else 0
+
+    # Currently playing section.
+    current_section = ""
+    if player.current_entry:
+        progress = format_song_duration(player.progress)
+        duration = (
+            format_song_duration(player.current_entry.duration_td)
+            if player.current_entry.duration is not None
+            else "unknown duration"
+        )
+        added_by = (
+            player.current_entry.author.name
+            if player.current_entry.author
+            else "autoplaylist"
+        )
+        current_section = (
+            f"Currently playing: **{player.current_entry.title}** "
+            f"added by **{added_by}**. `({progress} / {duration})`\n\n"
+        )
+
+    # Queue entries for this page.
+    start = bot.config.queue_length * page
+    end = start + bot.config.queue_length
+    tracks = ""
+    for idx, entry in enumerate(list(player.playlist.entries)[start:end], start + 1):
+        if entry == player.current_entry:
+            continue
+        added_by = entry.author.name if entry.channel and entry.author else "autoplaylist"
+        title = entry.title[:40] + " ..." if len(entry.title) > 40 else entry.title
+        line = f"`{idx}` — **{title}** added by **{added_by}**\n"
+        if len(tracks) + len(line) < 3840:
+            tracks += line
+
+    if total:
+        body = tracks
+        if pages_total > 0:
+            body += f"\nPage {page + 1}/{pages_total + 1}"
+    else:
+        body = "The queue is empty."
+
+    embed = discord.Embed(
+        description=f"{current_section}{body}",
+        title="Queue",
+        color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_NORMAL),
+    )
+    return embed, pages_total
+
+
+# ------------------------------------------------------------------ #
+#  Paginated queue view                                                #
+# ------------------------------------------------------------------ #
+
+class QueueView(discord.ui.View):
+    """
+    Adds ◀ ▶ navigation buttons to the queue embed.
+    Buttons are disabled when there is only one page.
+    """
+
+    def __init__(
+        self,
+        bot: "MusicBot",
+        player: "MusicPlayer",
+        page: int,
+        pages_total: int,
+    ) -> None:
+        super().__init__(timeout=120)
+        self.bot = bot
+        self.player = player
+        self.page = page
+        self.pages_total = pages_total
+
+        if pages_total == 0:
+            self.prev_btn.disabled = True
+            self.next_btn.disabled = True
+
+    async def _update(self, interaction: discord.Interaction) -> None:
+        embed, self.pages_total = _build_queue_embed(self.bot, self.player, self.page)
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    async def on_timeout(self) -> None:
+        self.prev_btn.disabled = True
+        self.next_btn.disabled = True
+
+    @discord.ui.button(label="◀", style=discord.ButtonStyle.secondary)
+    async def prev_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        self.page = self.pages_total if self.page <= 0 else self.page - 1
+        await self._update(interaction)
+
+    @discord.ui.button(label="▶", style=discord.ButtonStyle.secondary)
+    async def next_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        self.page = 0 if self.page >= self.pages_total else self.page + 1
+        await self._update(interaction)
+
+
+# ------------------------------------------------------------------ #
+#  Autocomplete helpers                                                #
+# ------------------------------------------------------------------ #
+
+async def _queue_position_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> List[app_commands.Choice[int]]:
+    """Autocomplete returning current queue entries by position."""
+    bot: "MusicBot" = interaction.client  # type: ignore[assignment]
+    if not interaction.guild:
+        return []
+    player = bot.get_player_in(interaction.guild)
+    if not player or not player.playlist.entries:
+        return []
+
+    choices = []
+    for i, entry in enumerate(player.playlist.entries, 1):
+        label = f"{i}. {entry.title}"[:100]
+        if current and current not in str(i) and current.lower() not in label.lower():
+            continue
+        choices.append(app_commands.Choice(name=label, value=i))
+        if len(choices) >= 25:
+            break
+    return choices
+
+
+# ------------------------------------------------------------------ #
+#  Registration                                                        #
+# ------------------------------------------------------------------ #
+
+def register(bot: "MusicBot") -> None:
+    """Register all queue slash commands with the bot's CommandTree."""
+
+    queue_group = app_commands.Group(
+        name="queue",
+        description="View and manage the song queue.",
+    )
+
+    # ---------------------------------------------------------------- #
+    #  /queue list                                                       #
+    # ---------------------------------------------------------------- #
+
+    @queue_group.command(
+        name="list", description="Show the current song queue with page navigation."
+    )
+    @app_commands.describe(page="Page number to jump to (default: 1).")
+    async def queue_list(
+        interaction: discord.Interaction, page: int = 1
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("queue")
+        player = await ctx.get_player()
+
+        total = len(player.playlist.entries)
+        if not total and not player.current_entry:
+            raise exceptions.CommandError(
+                "There are no songs queued! Queue something with `/play`."
+            )
+
+        page_index = max(0, page - 1)
+        pages_total = math.ceil(total / bot.config.queue_length) - 1 if total else 0
+
+        if page_index > pages_total:
+            raise exceptions.CommandError(
+                f"Page {page} is out of range. There are **{pages_total + 1}** page(s)."
+            )
+
+        embed, pages_total = _build_queue_embed(bot, player, page_index)
+        view = QueueView(bot, player, page_index, pages_total)
+        await respond_with_embed(interaction, embed, view=view)
+
+    # ---------------------------------------------------------------- #
+    #  /queue clear                                                      #
+    # ---------------------------------------------------------------- #
+
+    @queue_group.command(name="clear", description="Clear all songs from the queue.")
+    async def queue_clear(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("clear")
+        guild = ctx.require_guild()
+        _player = ctx.get_player_in()
+
+        response = await bot.cmd_clear(ssd_=ctx.ssd, _player=_player, guild=guild)
+        if response:
+            await invoke_response(interaction, response)
+        else:
+            await respond(interaction, "Queue cleared.")
+
+    # ---------------------------------------------------------------- #
+    #  /queue shuffle                                                    #
+    # ---------------------------------------------------------------- #
+
+    @queue_group.command(name="shuffle", description="Shuffle the song queue.")
+    async def queue_shuffle(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("shuffle")
+        player = await ctx.get_player()
+
+        if not player.playlist.entries:
+            raise exceptions.CommandError("There's nothing in the queue to shuffle.")
+
+        player.playlist.shuffle()
+        await respond(interaction, "The queue has been shuffled.")
+
+    # ---------------------------------------------------------------- #
+    #  /queue remove                                                     #
+    # ---------------------------------------------------------------- #
+
+    @queue_group.command(
+        name="remove",
+        description="Remove a song from the queue by position.",
+    )
+    @app_commands.describe(position="Position of the song to remove.")
+    @app_commands.autocomplete(position=_queue_position_autocomplete)
+    async def queue_remove(
+        interaction: discord.Interaction, position: int
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("remove")
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a voice channel."
+            )
+
+        player = await ctx.get_player()
+
+        if not player.playlist.entries:
+            raise exceptions.CommandError("There's nothing in the queue to remove.")
+
+        if position < 1 or position > len(player.playlist.entries):
+            raise exceptions.CommandError(
+                f"Invalid position. The queue has **{len(player.playlist.entries)}** song(s)."
+            )
+
+        entry = player.playlist.get_entry_at_index(position - 1)
+
+        if not ctx.permissions.remove and entry.author != ctx.author:
+            raise exceptions.PermissionsError(
+                "You can only remove songs you added yourself."
+            )
+
+        player.playlist.delete_entry_at_index(position - 1)
+        added_by = f" added by **{entry.author.name}**" if entry.author else ""
+        await respond(
+            interaction, f"Removed **{entry.title}**{added_by} from the queue."
+        )
+
+    bot.tree.add_command(queue_group)
+
+    # ---------------------------------------------------------------- #
+    #  /promote                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="promote",
+        description="Move a queued song to the front so it plays next.",
+    )
+    @app_commands.describe(position="Position of the song to promote.")
+    @app_commands.autocomplete(position=_queue_position_autocomplete)
+    async def slash_promote(
+        interaction: discord.Interaction, position: Optional[int] = None
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("promote")
+        player = await ctx.get_player()
+
+        pos_str = str(position) if position is not None else ""
+        response = await bot.cmd_promote(
+            ssd_=ctx.ssd, player=player, position=pos_str
+        )
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /move                                                             #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="move",
+        description="Move a song from one queue position to another.",
+    )
+    @app_commands.describe(
+        from_position="Current position of the song.",
+        to_position="Position to move it to.",
+    )
+    @app_commands.autocomplete(from_position=_queue_position_autocomplete)
+    async def slash_move(
+        interaction: discord.Interaction,
+        from_position: int,
+        to_position: int,
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("move")
+        player = await ctx.get_player()
+        queue_len = len(player.playlist.entries)
+
+        if not player.current_entry:
+            raise exceptions.CommandError(
+                "There are no songs queued. Queue something with `/play`."
+            )
+
+        for pos, label in [(from_position, "from"), (to_position, "to")]:
+            if pos < 1 or pos > queue_len:
+                raise exceptions.CommandError(
+                    f"The {label} position ({pos}) is outside the queue range (1–{queue_len})."
+                )
+
+        song = player.playlist.delete_entry_at_index(from_position - 1)
+        player.playlist.insert_entry_at_index(to_position - 1, song)
+
+        await respond(
+            interaction,
+            f"Moved **{song.title}** from position {from_position} to {to_position}.",
+        )

--- a/musicbot/slash/queue.py
+++ b/musicbot/slash/queue.py
@@ -1,13 +1,11 @@
 """
 Slash commands — Phase 3: queue management.
-/queue list  /queue clear  /queue shuffle  /queue remove
-/promote  /move
+/queue  /clearqueue  /shufflequeue  /removequeue  /promote  /move
 """
 from __future__ import annotations
 
 import logging
 import math
-from collections import deque
 from typing import TYPE_CHECKING, List, Optional
 
 import discord
@@ -173,20 +171,16 @@ async def _queue_position_autocomplete(
 def register(bot: "MusicBot") -> None:
     """Register all queue slash commands with the bot's CommandTree."""
 
-    queue_group = app_commands.Group(
+    # ---------------------------------------------------------------- #
+    #  /queue                                                            #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
         name="queue",
-        description="View and manage the song queue.",
-    )
-
-    # ---------------------------------------------------------------- #
-    #  /queue list                                                       #
-    # ---------------------------------------------------------------- #
-
-    @queue_group.command(
-        name="list", description="Show the current song queue with page navigation."
+        description="Show the current song queue with page navigation.",
     )
     @app_commands.describe(page="Page number to jump to (default: 1).")
-    async def queue_list(
+    async def slash_queue(
         interaction: discord.Interaction, page: int = 1
     ) -> None:
         ctx = SlashContext(interaction, bot)
@@ -212,11 +206,11 @@ def register(bot: "MusicBot") -> None:
         await respond_with_embed(interaction, embed, view=view)
 
     # ---------------------------------------------------------------- #
-    #  /queue clear                                                      #
+    #  /clearqueue                                                       #
     # ---------------------------------------------------------------- #
 
-    @queue_group.command(name="clear", description="Clear all songs from the queue.")
-    async def queue_clear(interaction: discord.Interaction) -> None:
+    @bot.tree.command(name="clearqueue", description="Clear all songs from the queue.")
+    async def slash_clearqueue(interaction: discord.Interaction) -> None:
         ctx = SlashContext(interaction, bot)
         ctx.check_permission("clear")
         guild = ctx.require_guild()
@@ -229,11 +223,11 @@ def register(bot: "MusicBot") -> None:
             await respond(interaction, "Queue cleared.")
 
     # ---------------------------------------------------------------- #
-    #  /queue shuffle                                                    #
+    #  /shufflequeue                                                     #
     # ---------------------------------------------------------------- #
 
-    @queue_group.command(name="shuffle", description="Shuffle the song queue.")
-    async def queue_shuffle(interaction: discord.Interaction) -> None:
+    @bot.tree.command(name="shufflequeue", description="Shuffle the song queue.")
+    async def slash_shufflequeue(interaction: discord.Interaction) -> None:
         ctx = SlashContext(interaction, bot)
         ctx.check_permission("shuffle")
         player = await ctx.get_player()
@@ -245,16 +239,16 @@ def register(bot: "MusicBot") -> None:
         await respond(interaction, "The queue has been shuffled.")
 
     # ---------------------------------------------------------------- #
-    #  /queue remove                                                     #
+    #  /removequeue                                                      #
     # ---------------------------------------------------------------- #
 
-    @queue_group.command(
-        name="remove",
+    @bot.tree.command(
+        name="removequeue",
         description="Remove a song from the queue by position.",
     )
     @app_commands.describe(position="Position of the song to remove.")
     @app_commands.autocomplete(position=_queue_position_autocomplete)
-    async def queue_remove(
+    async def slash_removequeue(
         interaction: discord.Interaction, position: int
     ) -> None:
         ctx = SlashContext(interaction, bot)
@@ -287,8 +281,6 @@ def register(bot: "MusicBot") -> None:
         await respond(
             interaction, f"Removed **{entry.title}**{added_by} from the queue."
         )
-
-    bot.tree.add_command(queue_group)
 
     # ---------------------------------------------------------------- #
     #  /promote                                                          #

--- a/musicbot/slash/queue.py
+++ b/musicbot/slash/queue.py
@@ -14,7 +14,7 @@ from discord import app_commands
 from musicbot import exceptions
 from musicbot.constants import MUSICBOT_EMBED_COLOR_NORMAL
 from musicbot.slash.context import SlashContext
-from musicbot.slash.responses import defer, invoke_response, respond, respond_with_embed
+from musicbot.slash.responses import defer, invoke_response, respond, respond_with_embed, schedule_delete
 from musicbot.utils import format_song_duration
 
 if TYPE_CHECKING:
@@ -148,6 +148,9 @@ class QueueView(discord.ui.View):
                 await self.message.edit(view=self)
             except discord.HTTPException:
                 pass
+            cfg = getattr(self.bot, "config", None)
+            if cfg is not None and getattr(cfg, "delete_messages", False):
+                schedule_delete(self.message, cfg.delete_delay_short)
 
     @discord.ui.button(label="◀", style=discord.ButtonStyle.secondary)
     async def prev_btn(

--- a/musicbot/slash/queue.py
+++ b/musicbot/slash/queue.py
@@ -212,7 +212,13 @@ def register(bot: "MusicBot") -> None:
     ) -> None:
         ctx = SlashContext(interaction, bot)
         ctx.check_permission("queue")
-        player = await ctx.get_player()
+        ctx.require_guild()
+
+        player = ctx.get_player_in()
+        if player is None:
+            raise exceptions.CommandError(
+                "I'm not playing anything right now. Start something with `/play`."
+            )
 
         total = len(player.playlist.entries)
         if not total and not player.current_entry:

--- a/musicbot/slash/responses.py
+++ b/musicbot/slash/responses.py
@@ -17,6 +17,17 @@ from musicbot.constants import MUSICBOT_EMBED_COLOR_ERROR, MUSICBOT_EMBED_COLOR_
 log = logging.getLogger(__name__)
 
 
+def _schedule_delete(msg: discord.Message, delay: float) -> None:
+    """Delete a message after delay seconds in a background task."""
+    async def _delete() -> None:
+        await asyncio.sleep(delay)
+        try:
+            await msg.delete()
+        except discord.HTTPException:
+            pass
+    asyncio.create_task(_delete())
+
+
 async def respond(
     interaction: discord.Interaction,
     content: str,
@@ -48,11 +59,7 @@ async def respond(
         msg = await interaction.original_response()
 
     if delete_after and not ephemeral:
-        await asyncio.sleep(delete_after)
-        try:
-            await msg.delete()
-        except discord.HTTPException:
-            pass
+        _schedule_delete(msg, delete_after)
 
 
 async def respond_with_embed(
@@ -78,11 +85,7 @@ async def respond_with_embed(
         msg = await interaction.original_response()
 
     if delete_after and not ephemeral:
-        await asyncio.sleep(delete_after)
-        try:
-            await msg.delete()
-        except discord.HTTPException:
-            pass
+        _schedule_delete(msg, delete_after)
 
     return msg
 

--- a/musicbot/slash/responses.py
+++ b/musicbot/slash/responses.py
@@ -67,19 +67,14 @@ async def respond_with_embed(
     Send a pre-built embed as a slash command response.
     Returns the sent message for later editing or deletion.
     """
+    kwargs: dict = {"embed": embed, "ephemeral": ephemeral}
+    if view is not None:
+        kwargs["view"] = view
+
     if interaction.response.is_done():
-        msg = await interaction.followup.send(
-            embed=embed,
-            ephemeral=ephemeral,
-            view=view,
-            wait=True,
-        )
+        msg = await interaction.followup.send(**kwargs, wait=True)
     else:
-        await interaction.response.send_message(
-            embed=embed,
-            ephemeral=ephemeral,
-            view=view,
-        )
+        await interaction.response.send_message(**kwargs)
         msg = await interaction.original_response()
 
     if delete_after and not ephemeral:

--- a/musicbot/slash/responses.py
+++ b/musicbot/slash/responses.py
@@ -40,7 +40,7 @@ async def respond(
     """
     Send an embed response to a slash command interaction.
     Works whether the interaction has been deferred or not.
-    Non-ephemeral responses can be auto-deleted after delete_after seconds.
+    Non-ephemeral responses auto-delete per bot config when delete_after is unset.
     """
     embed = discord.Embed(
         description=content,
@@ -58,8 +58,14 @@ async def respond(
         await interaction.response.send_message(embed=embed, ephemeral=ephemeral)
         msg = await interaction.original_response()
 
-    if delete_after and not ephemeral:
-        _schedule_delete(msg, delete_after)
+    if not ephemeral:
+        effective_delay = delete_after
+        if effective_delay is None:
+            cfg = getattr(interaction.client, "config", None)
+            if cfg is not None and getattr(cfg, "delete_messages", False):
+                effective_delay = cfg.delete_delay_short
+        if effective_delay:
+            _schedule_delete(msg, effective_delay)
 
 
 async def respond_with_embed(
@@ -113,11 +119,15 @@ async def invoke_response(
 ) -> None:
     """
     Send a MusicBotResponse (Response / ErrorResponse) as an interaction
-    response. Preserves the response's delete_after value if set.
+    response. Mirrors the prefix command auto-delete fallback from bot.py.
     """
     if response is None:
         return
     delete_after = getattr(response, "delete_after", None)
+    if delete_after is None:
+        cfg = getattr(interaction.client, "config", None)
+        if cfg is not None and getattr(cfg, "delete_messages", False):
+            delete_after = cfg.delete_delay_short
     await respond_with_embed(
         interaction,
         response,

--- a/musicbot/slash/responses.py
+++ b/musicbot/slash/responses.py
@@ -107,6 +107,27 @@ async def respond_error(
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
+async def invoke_response(
+    interaction: discord.Interaction,
+    response: "Optional[discord.Embed]",
+    *,
+    view: Optional[discord.ui.View] = None,
+) -> None:
+    """
+    Send a MusicBotResponse (Response / ErrorResponse) as an interaction
+    response. Preserves the response's delete_after value if set.
+    """
+    if response is None:
+        return
+    delete_after = getattr(response, "delete_after", None)
+    await respond_with_embed(
+        interaction,
+        response,
+        delete_after=delete_after,
+        view=view,
+    )
+
+
 async def defer(
     interaction: discord.Interaction,
     *,

--- a/musicbot/slash/responses.py
+++ b/musicbot/slash/responses.py
@@ -17,7 +17,7 @@ from musicbot.constants import MUSICBOT_EMBED_COLOR_ERROR, MUSICBOT_EMBED_COLOR_
 log = logging.getLogger(__name__)
 
 
-def _schedule_delete(msg: discord.Message, delay: float) -> None:
+def schedule_delete(msg: discord.Message, delay: float) -> None:
     """Delete a message after delay seconds in a background task."""
     async def _delete() -> None:
         await asyncio.sleep(delay)
@@ -65,7 +65,7 @@ async def respond(
             if cfg is not None and getattr(cfg, "delete_messages", False):
                 effective_delay = cfg.delete_delay_short
         if effective_delay:
-            _schedule_delete(msg, effective_delay)
+            schedule_delete(msg, effective_delay)
 
 
 async def respond_with_embed(
@@ -91,7 +91,7 @@ async def respond_with_embed(
         msg = await interaction.original_response()
 
     if delete_after and not ephemeral:
-        _schedule_delete(msg, delete_after)
+        schedule_delete(msg, delete_after)
 
     return msg
 

--- a/musicbot/slash/responses.py
+++ b/musicbot/slash/responses.py
@@ -1,0 +1,120 @@
+"""
+Response utilities for slash command interactions.
+
+Handles the interaction response lifecycle: immediate send, deferred
+followup, ephemeral errors, and optional auto-delete.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import discord
+
+from musicbot.constants import MUSICBOT_EMBED_COLOR_ERROR, MUSICBOT_EMBED_COLOR_NORMAL
+
+log = logging.getLogger(__name__)
+
+
+async def respond(
+    interaction: discord.Interaction,
+    content: str,
+    *,
+    title: Optional[str] = None,
+    ephemeral: bool = False,
+    delete_after: Optional[float] = None,
+    color_hex: str = MUSICBOT_EMBED_COLOR_NORMAL,
+) -> None:
+    """
+    Send an embed response to a slash command interaction.
+    Works whether the interaction has been deferred or not.
+    Non-ephemeral responses can be auto-deleted after delete_after seconds.
+    """
+    embed = discord.Embed(
+        description=content,
+        color=discord.Colour.from_str(color_hex),
+        title=title,
+    )
+
+    if interaction.response.is_done():
+        msg = await interaction.followup.send(
+            embed=embed,
+            ephemeral=ephemeral,
+            wait=True,
+        )
+    else:
+        await interaction.response.send_message(embed=embed, ephemeral=ephemeral)
+        msg = await interaction.original_response()
+
+    if delete_after and not ephemeral:
+        await asyncio.sleep(delete_after)
+        try:
+            await msg.delete()
+        except discord.HTTPException:
+            pass
+
+
+async def respond_with_embed(
+    interaction: discord.Interaction,
+    embed: discord.Embed,
+    *,
+    ephemeral: bool = False,
+    delete_after: Optional[float] = None,
+    view: Optional[discord.ui.View] = None,
+) -> discord.Message:
+    """
+    Send a pre-built embed as a slash command response.
+    Returns the sent message for later editing or deletion.
+    """
+    if interaction.response.is_done():
+        msg = await interaction.followup.send(
+            embed=embed,
+            ephemeral=ephemeral,
+            view=view,
+            wait=True,
+        )
+    else:
+        await interaction.response.send_message(
+            embed=embed,
+            ephemeral=ephemeral,
+            view=view,
+        )
+        msg = await interaction.original_response()
+
+    if delete_after and not ephemeral:
+        await asyncio.sleep(delete_after)
+        try:
+            await msg.delete()
+        except discord.HTTPException:
+            pass
+
+    return msg
+
+
+async def respond_error(
+    interaction: discord.Interaction,
+    content: str,
+) -> None:
+    """Send an ephemeral error embed. Only the invoker sees it."""
+    embed = discord.Embed(
+        description=content,
+        color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_ERROR),
+    )
+    if interaction.response.is_done():
+        await interaction.followup.send(embed=embed, ephemeral=True)
+    else:
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+async def defer(
+    interaction: discord.Interaction,
+    *,
+    ephemeral: bool = False,
+) -> None:
+    """
+    Defer an interaction response for long-running operations.
+    Must be called within 3 seconds of the interaction, before any other response.
+    """
+    if not interaction.response.is_done():
+        await interaction.response.defer(ephemeral=ephemeral)

--- a/musicbot/slash/utility.py
+++ b/musicbot/slash/utility.py
@@ -1,0 +1,283 @@
+"""
+Slash commands — Phase 6: utility.
+/np  /botinfo  /botversion  /uptime  /latency  /perms
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import discord
+from discord import app_commands
+
+from musicbot import exceptions
+from musicbot.constants import (
+    BOTVERSION,
+    DEFAULT_BOT_NAME,
+    MUSICBOT_EMBED_COLOR_NORMAL,
+)
+from musicbot.entry import StreamPlaylistEntry
+from musicbot.slash.context import SlashContext
+from musicbot.slash.responses import invoke_response, respond
+from musicbot.utils import format_song_duration
+
+if TYPE_CHECKING:
+    from musicbot.bot import MusicBot
+    from musicbot.player import MusicPlayer
+
+log = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ #
+#  Now Playing view with control buttons                               #
+# ------------------------------------------------------------------ #
+
+class NowPlayingView(discord.ui.View):
+    """
+    Attaches ⏸/▶ · ⏭ · 🔁 buttons to the now-playing embed.
+    Any server member may use them.
+    """
+
+    def __init__(self, bot: "MusicBot", player: "MusicPlayer") -> None:
+        super().__init__(timeout=60)
+        self.bot = bot
+        self.player = player
+        self._refresh_pause_label()
+
+    def _refresh_pause_label(self) -> None:
+        if self.player.is_paused:
+            self.pause_resume_btn.label = "▶ Resume"
+            self.pause_resume_btn.style = discord.ButtonStyle.green
+        else:
+            self.pause_resume_btn.label = "⏸ Pause"
+            self.pause_resume_btn.style = discord.ButtonStyle.secondary
+
+    def _refresh_repeat_label(self) -> None:
+        if self.player.repeatsong:
+            self.repeat_btn.label = "🔁 Song (on)"
+            self.repeat_btn.style = discord.ButtonStyle.blurple
+        else:
+            self.repeat_btn.label = "🔁 Repeat"
+            self.repeat_btn.style = discord.ButtonStyle.secondary
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+
+    @discord.ui.button(label="⏸ Pause", style=discord.ButtonStyle.secondary)
+    async def pause_resume_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if self.player.is_paused:
+            self.player.resume()
+        elif self.player.is_playing:
+            self.player.pause()
+        else:
+            await interaction.response.send_message(
+                "Nothing is playing right now.", ephemeral=True
+            )
+            return
+        self._refresh_pause_label()
+        await interaction.response.edit_message(view=self)
+
+    @discord.ui.button(label="⏭ Skip", style=discord.ButtonStyle.secondary)
+    async def skip_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if not self.player.is_playing and not self.player.is_paused:
+            await interaction.response.send_message(
+                "Nothing is playing right now.", ephemeral=True
+            )
+            return
+        self.player.skip()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        await interaction.response.edit_message(view=self)
+
+    @discord.ui.button(label="🔁 Repeat", style=discord.ButtonStyle.secondary)
+    async def repeat_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        self.player.repeatsong = not self.player.repeatsong
+        self._refresh_repeat_label()
+        await interaction.response.edit_message(view=self)
+
+
+# ------------------------------------------------------------------ #
+#  Now Playing embed builder                                           #
+# ------------------------------------------------------------------ #
+
+def _build_np_embed(player: "MusicPlayer") -> discord.Embed:
+    entry = player.current_entry
+    streaming = isinstance(entry, StreamPlaylistEntry)
+
+    song_progress = format_song_duration(player.progress)
+    song_total = (
+        format_song_duration(entry.duration_td)
+        if entry.duration is not None
+        else "~"
+    )
+    prog_str = (
+        f"`({song_progress})`"
+        if streaming
+        else f"`({song_progress} / {song_total})`"
+    )
+
+    percentage = 0.0
+    if entry.duration and entry.duration_td.total_seconds() > 0:
+        percentage = player.progress / entry.duration_td.total_seconds()
+
+    bar_length = 30
+    bar = "".join(
+        "■" if percentage >= (i / bar_length) else "□"
+        for i in range(bar_length)
+    )
+
+    added_by = entry.author.name if entry.author else "autoplaylist"
+
+    embed = discord.Embed(
+        title=entry.title,
+        color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_NORMAL),
+    )
+    embed.add_field(name="Added By:", value=f"`{added_by}`", inline=False)
+    embed.add_field(name="Progress:", value=f"{prog_str}\n{bar}", inline=False)
+
+    display_url = entry.info.input_subject if streaming else entry.url
+    if display_url and len(display_url) <= 1024:
+        embed.add_field(name="URL:", value=display_url, inline=False)
+
+    if entry.thumbnail_url:
+        embed.set_image(url=entry.thumbnail_url)
+
+    return embed
+
+
+# ------------------------------------------------------------------ #
+#  Registration                                                        #
+# ------------------------------------------------------------------ #
+
+def register(bot: "MusicBot") -> None:
+    """Register all utility slash commands with the bot's CommandTree."""
+
+    # ---------------------------------------------------------------- #
+    #  /np                                                               #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="np",
+        description="Show what's currently playing with playback controls.",
+    )
+    async def slash_np(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("np")
+        player = await ctx.get_player()
+
+        if not player.current_entry:
+            raise exceptions.CommandError(
+                "There are no songs queued! Queue something with `/play`."
+            )
+
+        embed = _build_np_embed(player)
+        view = NowPlayingView(bot, player)
+
+        await interaction.response.send_message(embed=embed, view=view)
+
+    # ---------------------------------------------------------------- #
+    #  /botinfo                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="botinfo",
+        description="Show DJ Roomba version, links, and credits.",
+    )
+    async def slash_botinfo(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        response = await bot.cmd_botinfo(message=None)
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /botversion                                                       #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="botversion",
+        description="Show the current DJ Roomba version.",
+    )
+    async def slash_botversion(interaction: discord.Interaction) -> None:
+        await respond(
+            interaction,
+            f"DJ-Roomba GitHub: <https://github.com/Jimgersnap/DJ-Roomba>\n"
+            f"Current version: `{BOTVERSION}`",
+        )
+
+    # ---------------------------------------------------------------- #
+    #  /uptime                                                           #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="uptime",
+        description="Show how long DJ Roomba has been running.",
+    )
+    async def slash_uptime(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        response = await bot.cmd_uptime(ssd_=ctx.ssd)
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /latency                                                          #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="latency",
+        description="Show API and voice latency.",
+    )
+    async def slash_latency(interaction: discord.Interaction) -> None:
+        ctx = SlashContext(interaction, bot)
+        guild = ctx.require_guild()
+        response = await bot.cmd_latency(ssd_=ctx.ssd, guild=guild)
+        await invoke_response(interaction, response)
+
+    # ---------------------------------------------------------------- #
+    #  /perms                                                            #
+    # ---------------------------------------------------------------- #
+
+    @bot.tree.command(
+        name="perms",
+        description="Show your permissions, or another member's.",
+    )
+    @app_commands.describe(user="Member to check permissions for. Defaults to you.")
+    async def slash_perms(
+        interaction: discord.Interaction,
+        user: Optional[discord.Member] = None,
+    ) -> None:
+        ctx = SlashContext(interaction, bot)
+        ctx.check_permission("perms")
+        guild = ctx.require_guild()
+
+        if not isinstance(ctx.author, discord.Member):
+            raise exceptions.CommandError(
+                "This command requires you to be in a server."
+            )
+
+        target = user or ctx.author
+        perms = bot.permissions.for_user(target)
+
+        if target == ctx.author:
+            content = (
+                f"Your command permissions in **{guild.name}** are:\n"
+                f"```\n{perms.format(for_user=True)}\n```"
+            )
+        else:
+            content = (
+                f"Command permissions for **{target.name}** in **{guild.name}**:\n"
+                f"```\n{perms.format()}\n```"
+            )
+
+        # Send ephemeral — permissions info is personal, keeps channels clean.
+        embed = discord.Embed(
+            description=content,
+            color=discord.Colour.from_str(MUSICBOT_EMBED_COLOR_NORMAL),
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/musicbot/slash/utility.py
+++ b/musicbot/slash/utility.py
@@ -184,23 +184,33 @@ def register(bot: "MusicBot") -> None:
 
     @bot.tree.command(
         name="nowplaying",
-        description="Show what's currently playing with playback controls.",
+        description="Refresh the now-playing message to the bottom of chat.",
     )
     async def slash_np(interaction: discord.Interaction) -> None:
         ctx = SlashContext(interaction, bot)
         ctx.check_permission("np")
-        player = await ctx.get_player()
+        guild = ctx.require_guild()
 
-        if not player.current_entry:
-            raise exceptions.CommandError(
-                "There are no songs queued! Queue something with `/play`."
-            )
+        player = ctx.get_player_in()
+        if player is None or not player.current_entry:
+            raise exceptions.CommandError("Nothing is playing right now.")
+
+        # Delete the existing auto-NP message to avoid redundancy.
+        old_np_msg = bot.server_data[guild.id].last_np_msg
+        if old_np_msg:
+            try:
+                await old_np_msg.delete()
+            except discord.HTTPException:
+                pass
+            bot.server_data[guild.id].last_np_msg = None
 
         embed = _build_np_embed(player)
-        view = NowPlayingView(bot, player)
+        view = NowPlayingView(bot, player, auto_delete=False)
 
         await interaction.response.send_message(embed=embed, view=view)
-        view.message = await interaction.original_response()
+        msg = await interaction.original_response()
+        view.message = msg
+        bot.server_data[guild.id].last_np_msg = msg
 
     # ---------------------------------------------------------------- #
     #  /botinfo                                                          #

--- a/musicbot/slash/utility.py
+++ b/musicbot/slash/utility.py
@@ -12,7 +12,7 @@ from discord import app_commands
 
 from musicbot import exceptions
 from musicbot.constants import (
-    BOTVERSION,
+    VERSION as BOTVERSION,
     DEFAULT_BOT_NAME,
     MUSICBOT_EMBED_COLOR_NORMAL,
 )

--- a/musicbot/slash/utility.py
+++ b/musicbot/slash/utility.py
@@ -183,7 +183,7 @@ def register(bot: "MusicBot") -> None:
     # ---------------------------------------------------------------- #
 
     @bot.tree.command(
-        name="np",
+        name="nowplaying",
         description="Show what's currently playing with playback controls.",
     )
     async def slash_np(interaction: discord.Interaction) -> None:

--- a/musicbot/slash/utility.py
+++ b/musicbot/slash/utility.py
@@ -38,11 +38,18 @@ class NowPlayingView(discord.ui.View):
     Any server member may use them.
     """
 
-    def __init__(self, bot: "MusicBot", player: "MusicPlayer") -> None:
-        super().__init__(timeout=60)
+    def __init__(
+        self,
+        bot: "MusicBot",
+        player: "MusicPlayer",
+        *,
+        auto_delete: bool = True,
+    ) -> None:
+        super().__init__(timeout=60 if auto_delete else None)
         self.bot = bot
         self.player = player
         self.message: Optional[discord.Message] = None
+        self._auto_delete = auto_delete
         self._refresh_pause_label()
 
     def _refresh_pause_label(self) -> None:
@@ -70,9 +77,10 @@ class NowPlayingView(discord.ui.View):
                 await self.message.edit(view=self)
             except discord.HTTPException:
                 pass
-            cfg = getattr(self.bot, "config", None)
-            if cfg is not None and getattr(cfg, "delete_messages", False):
-                schedule_delete(self.message, cfg.delete_delay_short)
+            if self._auto_delete:
+                cfg = getattr(self.bot, "config", None)
+                if cfg is not None and getattr(cfg, "delete_messages", False):
+                    schedule_delete(self.message, cfg.delete_delay_short)
 
     @discord.ui.button(label="⏸ Pause", style=discord.ButtonStyle.secondary)
     async def pause_resume_btn(

--- a/musicbot/slash/utility.py
+++ b/musicbot/slash/utility.py
@@ -18,7 +18,7 @@ from musicbot.constants import (
 )
 from musicbot.entry import StreamPlaylistEntry
 from musicbot.slash.context import SlashContext
-from musicbot.slash.responses import invoke_response, respond
+from musicbot.slash.responses import invoke_response, respond, schedule_delete
 from musicbot.utils import format_song_duration
 
 if TYPE_CHECKING:
@@ -42,6 +42,7 @@ class NowPlayingView(discord.ui.View):
         super().__init__(timeout=60)
         self.bot = bot
         self.player = player
+        self.message: Optional[discord.Message] = None
         self._refresh_pause_label()
 
     def _refresh_pause_label(self) -> None:
@@ -64,6 +65,14 @@ class NowPlayingView(discord.ui.View):
         for child in self.children:
             if isinstance(child, discord.ui.Button):
                 child.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except discord.HTTPException:
+                pass
+            cfg = getattr(self.bot, "config", None)
+            if cfg is not None and getattr(cfg, "delete_messages", False):
+                schedule_delete(self.message, cfg.delete_delay_short)
 
     @discord.ui.button(label="⏸ Pause", style=discord.ButtonStyle.secondary)
     async def pause_resume_btn(
@@ -183,6 +192,7 @@ def register(bot: "MusicBot") -> None:
         view = NowPlayingView(bot, player)
 
         await interaction.response.send_message(embed=embed, view=view)
+        view.message = await interaction.original_response()
 
     # ---------------------------------------------------------------- #
     #  /botinfo                                                          #


### PR DESCRIPTION
## Summary

Adds full Discord **slash-command** support to DJ-Roomba alongside the existing prefix commands. The bot now registers native `/` commands (with autocomplete, argument validation, and interactive components) that reuse the existing player/queue logic. Built out across 8 phases into a new `musicbot/slash/` package (~2,600 lines), followed by a round of interaction-timeout and auto-cleanup fixes.

## What's included

**Infrastructure**
- New `musicbot/slash/` package: command registration, an interaction-context adapter so slash handlers can reuse existing command logic, and shared embed/response helpers
- Slash commands sync to a guild on join (`copy_global_to_guild` before guild sync)
- ~50 slash commands mirroring the prefix command set

**Command coverage**
- **Playback**: `/play`, `/playnext`, `/playnow`, `/stream`, `/search`, `/pause`, `/resume`, `/skip`, `/seek`, `/stop`, `/summon`, `/disconnect`
- **Queue**: `/queue`, `/clearqueue`, `/shufflequeue`, `/removequeue`, `/nowplaying`
- **Playback options**: `/volume`, `/speed`, `/repeat`, `/karaoke`, `/shuffleplay`, `/autoplaylist`, `/move`, `/remove`, `/add`
- **Bot control**: `/reconnect`, `/restart`, `/shutdown`, `/reset`, `/setavatar`, `/setname`, `/setnick`, `/status`
- **Utility**: `/botinfo`, `/botversion`, `/uptime`, `/latency`, `/id`, `/promote`, `/clean`, `/perms`, `/language`
- **Admin**: `/set`, `/show`, `/blocksong`, `/blockuser`, `/checkupdates`, `/pldump`, `/resetplaylist`, `/follow`, `/setavatar`

**UX / cleanup (DJ-Roomba presence style)**
- Interactive embeds auto-delete after their view times out (`/nowplaying`, `/queue`, `/search`)
- `/nowplaying` replaces the auto now-playing message and registers as `last_np_msg` so the normal bot lifecycle cleans it up
- Playback control buttons added to auto now-playing messages
- `/search` result is scheduled for deletion once a song is added to the queue

## Fixes folded in

- Deferred `/disconnect` and `/reconnect` to avoid interaction timeouts
- `/queue` uses `get_player_in()` to avoid voice-connection timeouts; `QueueView` gained error handling and disabled-state sync on page changes
- `delete_after` runs as a background task so it isn't cancelled with the interaction
- Bot-config auto-delete fallback now applies to slash responses
- Fixed `view=None` TypeError in `respond_with_embed` and a `BOTVERSION` import
- Fixed inactivity timer not expiring after reconnect

## Notes

- Preserves all DJ-Roomba custom commands, config options, and response style
- Prefix commands are unchanged; slash commands are additive
